### PR TITLE
Enhance Remote Configuration and Validation with Custom Remote Option

### DIFF
--- a/src/config/validation.mjs
+++ b/src/config/validation.mjs
@@ -14,7 +14,7 @@ import {
  * @returns {Promise<object>} Configuration and repository information
  * @throws {Error} If configuration or repository validation fails
  */
-export const validateConfigAndRepository = async () => {
+export const validateConfigAndRepository = async (remoteName) => {
     // Get configuration
     let config;
     try {
@@ -42,10 +42,10 @@ export const validateConfigAndRepository = async () => {
     // Detect repository type from git remote
     let repoInfo;
     try {
-        repoInfo = await getRepositoryFromRemote();
+        repoInfo = await getRepositoryFromRemote(remoteName);
     } catch (error) {
         throw new Error(
-            `Failed to detect repository from git remote: ${error.message}. Make sure you're in a git repository with an origin remote configured.`
+            `Failed to detect repository from git remote: ${error.message}. Make sure you're in a git repository with a '${remoteName}' remote configured.`
         );
     }
 
@@ -91,7 +91,7 @@ export const validateConfigAndRepository = async () => {
  * @returns {Promise<{ githubSourceBranch: string, upstreamRef: string, upstreamRemote: string }>}
  * @throws {Error} if branch has no upstream, has unpushed commits, or is out of sync
  */
-export const validateBranchSyncAndGetRemote = async (localSourceBranch) => {
+export const validateBranchSyncAndGetRemote = async (localSourceBranch, defaultRemoteName) => {
     if (!localSourceBranch) {
         throw new Error("Local source branch name is required");
     }
@@ -100,7 +100,7 @@ export const validateBranchSyncAndGetRemote = async (localSourceBranch) => {
     const upstreamRef = await getUpstreamRef(localSourceBranch);
     if (!upstreamRef) {
         throw new Error(
-            `Branch '${localSourceBranch}' has no upstream tracking branch. Push it first with: git push -u origin ${localSourceBranch}`
+            `Branch '${localSourceBranch}' has no upstream tracking branch. Push it first with: git push -u ${defaultRemoteName} ${localSourceBranch}`
         );
     }
     const upstreamRemote = upstreamRef.split("/")[0];

--- a/src/gen-mr.mjs
+++ b/src/gen-mr.mjs
@@ -65,6 +65,9 @@ const showUsage = () => {
     console.log("                         Use with --global to save globally");
     console.log("  --show-config          Display current configuration");
     console.log("                         Use with --global to show only global config");
+    console.log(
+        "  --remote <name>        Use a specific git remote instead of 'origin' (optional)"
+    );
     console.log("  --help                 Show this help message");
     console.log("");
     console.log("Examples:");

--- a/src/gen-pr.mjs
+++ b/src/gen-pr.mjs
@@ -258,4 +258,7 @@ const main = async () => {
     );
 };
 
-main();
+main().catch((error) => {
+    console.error("❌ Error:", error.message);
+    process.exit(1);
+});

--- a/src/git-utils.mjs
+++ b/src/git-utils.mjs
@@ -106,6 +106,20 @@ export const getOriginRemote = async () => {
 };
 
 /**
+ * Get a named remote URL
+ * @param {string} remoteName - Remote name (e.g., origin, upstream)
+ * @returns {Promise<string>} Remote URL
+ */
+export const getRemoteUrl = async (remoteName) => {
+    try {
+        const { stdout } = await execAsync(`git config --get remote.${remoteName}.url`);
+        return stdout.trim();
+    } catch (error) {
+        throw new Error(`Failed to get remote '${remoteName}' url: ${error.message}`);
+    }
+};
+
+/**
  * Parse repository information from git remote URL
  * @param {string} remoteUrl - Git remote URL
  * @returns {object} Parsed repository information
@@ -163,12 +177,13 @@ export const detectRepoType = (hostname) => {
 };
 
 /**
- * Get repository information from git origin remote
+ * Get repository information from a named git remote
+ * @param {string} remoteName
  * @returns {Promise<object>} Repository type and details
  */
-export const getRepositoryFromRemote = async () => {
+export const getRepositoryFromRemote = async (remoteName) => {
     try {
-        const remoteUrl = await getOriginRemote();
+        const remoteUrl = await getRemoteUrl(remoteName);
         const repoInfo = parseRepoFromRemote(remoteUrl);
         const repoType = detectRepoType(repoInfo.hostname);
 

--- a/src/merge-request-generator.mjs
+++ b/src/merge-request-generator.mjs
@@ -87,15 +87,18 @@ export const generateMergeRequestSafe = async (
     jiraTickets = "",
     options = {}
 ) => {
-    const { verbose = false } = options;
+    const { verbose = false, remoteName, remoteSourceBranch } = options;
 
     try {
         if (verbose) {
             // Prefer a preformatted display name when provided (includes remote tracking info)
-            const displaySource = options.displaySourceBranch
-                ? options.displaySourceBranch
-                : formatSourceBranchDisplay(sourceBranch);
-            console.log(`🔍 Generating merge request for ${displaySource} → ${targetBranch}`);
+            const displaySource = formatSourceBranchDisplay(
+                sourceBranch,
+                remoteName,
+                remoteSourceBranch
+            );
+            const displayTarget = formatSourceBranchDisplay(targetBranch, remoteName, targetBranch);
+            console.log(`🔍 Generating merge request for ${displaySource} → ${displayTarget}`);
             if (jiraTickets) {
                 console.log(`🎫 Including JIRA tickets: ${jiraTickets}`);
             }

--- a/src/tests/git-utils.test.mjs
+++ b/src/tests/git-utils.test.mjs
@@ -23,17 +23,17 @@ beforeEach(() => {
 
 const callWith =
     (stdout = "", stderr = "") =>
-        (cmd, optionsOrCb, maybeCb) => {
-            const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
-            cb(null, stdout, stderr);
-        };
+    (cmd, optionsOrCb, maybeCb) => {
+        const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+        cb(null, stdout, stderr);
+    };
 
 const callError =
     (message = "boom") =>
-        (cmd, optionsOrCb, maybeCb) => {
-            const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
-            cb(new Error(message));
-        };
+    (cmd, optionsOrCb, maybeCb) => {
+        const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+        cb(new Error(message));
+    };
 
 describe("git-utils", () => {
     describe("getUpstreamRef", () => {
@@ -263,9 +263,9 @@ describe("git-utils", () => {
     });
 
     describe("getRepositoryFromRemote", () => {
-        test("detects from origin", async () => {
+        test("detects from specific remote (origin)", async () => {
             execMock.mockImplementation(callWith("git@github.com:owner/repo.git\n"));
-            const repo = await gitUtils.getRepositoryFromRemote();
+            const repo = await gitUtils.getRepositoryFromRemote("origin");
             expect(repo).toEqual({
                 type: "github",
                 hostname: "github.com",
@@ -276,10 +276,23 @@ describe("git-utils", () => {
             });
         });
 
+        test("detects from non-origin remote (upstream)", async () => {
+            execMock.mockImplementation(callWith("https://gitlab.com/group/proj.git\n"));
+            const repo = await gitUtils.getRepositoryFromRemote("upstream");
+            expect(repo).toEqual({
+                type: "gitlab",
+                hostname: "gitlab.com",
+                fullName: "group/proj",
+                owner: "group",
+                name: "proj",
+                remoteUrl: "https://gitlab.com/group/proj.git",
+            });
+        });
+
         test("handles error", async () => {
             execMock.mockImplementation(callError("bad remote"));
-            await expect(gitUtils.getRepositoryFromRemote()).rejects.toThrow(
-                "Failed to detect repository from remote: Failed to get origin remote: bad remote"
+            await expect(gitUtils.getRepositoryFromRemote("origin")).rejects.toThrow(
+                "Failed to detect repository from remote: Failed to get remote 'origin' url: bad remote"
             );
         });
     });

--- a/src/tests/git-utils.test.mjs
+++ b/src/tests/git-utils.test.mjs
@@ -23,17 +23,17 @@ beforeEach(() => {
 
 const callWith =
     (stdout = "", stderr = "") =>
-    (cmd, optionsOrCb, maybeCb) => {
-        const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
-        cb(null, stdout, stderr);
-    };
+        (cmd, optionsOrCb, maybeCb) => {
+            const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+            cb(null, stdout, stderr);
+        };
 
 const callError =
     (message = "boom") =>
-    (cmd, optionsOrCb, maybeCb) => {
-        const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
-        cb(new Error(message));
-    };
+        (cmd, optionsOrCb, maybeCb) => {
+            const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+            cb(new Error(message));
+        };
 
 describe("git-utils", () => {
     describe("getUpstreamRef", () => {

--- a/src/utils/branch-format.mjs
+++ b/src/utils/branch-format.mjs
@@ -12,5 +12,8 @@ export const formatSourceBranchDisplay = (local, remoteName, remoteBranch) => {
     if (remoteName && remoteBranch && remoteBranch !== local) {
         return `${local} (${remoteName}/${remoteBranch})`;
     }
+    if (remoteName !== "origin") {
+        return `${local} (${remoteName}/${local})`;
+    }
     return String(local || "");
 };

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -321,8 +321,9 @@ export const executePRWorkflow = async (
                 remoteName,
                 remoteSourceBranch
             );
+            const displayTarget = formatSourceBranchDisplay(targetBranch, remoteName, targetBranch);
             console.log("📋 Found existing pull request:");
-            console.log(`🔍 Source → target: ${displaySource} → ${targetBranch}`);
+            console.log(`🔍 Source → target: ${displaySource} → ${displayTarget}`);
             console.log(`   URL: ${existingPR.html_url}`);
             console.log(`   Status: ${existingPR.state}`);
             console.log(`   Title: ${existingPR.title}`);
@@ -348,11 +349,8 @@ export const executePRWorkflow = async (
                             aiModel: "ChatGPT",
                             promptOptions,
                             verbose: true,
-                            displaySourceBranch: formatSourceBranchDisplay(
-                                sourceBranch,
-                                remoteName,
-                                remoteSourceBranch
-                            ),
+                            remoteSourceBranch,
+                            remoteName,
                         }
                     );
                     break;
@@ -398,11 +396,8 @@ export const executePRWorkflow = async (
                     aiModel: "ChatGPT",
                     promptOptions,
                     verbose: true,
-                    displaySourceBranch: formatSourceBranchDisplay(
-                        sourceBranch,
-                        remoteName,
-                        remoteSourceBranch
-                    ),
+                    remoteSourceBranch,
+                    remoteName,
                 }
             );
         }

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -316,7 +316,13 @@ export const executePRWorkflow = async (
         let result;
 
         if (existingPR) {
+            const displaySource = formatSourceBranchDisplay(
+                remoteSourceBranch || sourceBranch,
+                remoteName,
+                remoteSourceBranch
+            );
             console.log("📋 Found existing pull request:");
+            console.log(`🔍 Source → target: ${displaySource} → ${targetBranch}`);
             console.log(`   URL: ${existingPR.html_url}`);
             console.log(`   Status: ${existingPR.state}`);
             console.log(`   Title: ${existingPR.title}`);


### PR DESCRIPTION
## Summary of Changes

This merge request enhances the configuration and validation processes by adding support for specifying a custom git remote name, rather than defaulting to 'origin'. The updates include modifying functions to accept a remote name as an argument and introducing a `--remote` option in the command-line interface.

## Purpose/Motivation

The motivation behind these changes is to provide flexibility in environments where the default 'origin' remote is not used. By allowing users to specify their preferred remote name, the tool becomes more adaptable to varying git workflows and configurations.

## Breaking Changes or Important Notes

- The update may require users to modify existing scripts or workflows if they depend on the default behavior of using 'origin' as the remote.
- The `--remote <name>` option is optional. If not specified, the system will default to 'origin'.

## Affected Files

- **Modified:** `src/config/validation.mjs`
- **Modified:** `src/gen-mr.mjs`
- **Modified:** `src/gen-pr.mjs`
- **Modified:** `src/git-utils.mjs`
- **Modified:** `src/merge-request-generator.mjs`
- **Modified:** `src/tests/git-utils.test.mjs`
- **Modified:** `src/utils/branch-format.mjs`
- **Modified:** `src/workflow.mjs`

## Testing Considerations

- Validate that specifying a different remote name using the `--remote` option effectively configures the repository and validation processes.
- Confirm that existing functionality remains unchanged when no remote is specified, defaulting to 'origin'.
- Execute the updated test cases in `src/tests/git-utils.test.mjs` to ensure expected behavior across various remote configurations.